### PR TITLE
Extra::EC2 overview and predictive cost module

### DIFF
--- a/lib/Extra/EC2.pm
+++ b/lib/Extra/EC2.pm
@@ -136,7 +136,7 @@ sub handler {
     $result->{"${type}_month_cost"}  = [ $month_cost, "n" ];
     $result->{"${type}_running"}     = [ $instances{type}{$t}{running}, "i" ];
 
-    $total_cost = $total_cost + $result->{"${type}_month_cost"};
+    $total_cost = $total_cost + $month_cost;
   }
 
   $result->{overview_total}    = [ $total_cost, "n" ];


### PR DESCRIPTION
This module requires Net::Amazon::EC2, so I placed it in the (new) lib/Extra directory.

It polls EC2 and returns information about instances and a predictive estimate of their cost. It does the same for security groups.

Example output:

```
overview_running = 85
overview_total = 10476.48

secgroup_database_day_cost = 50.04
secgroup_database_hour_cost = 2.085
secgroup_database_minute_cost = 0.03475
secgroup_database_month_cost = 1401.12
secgroup_database_running = 3

type_m1.small_day_cost = 81.6
type_m1.small_hour_cost = 3.4
type_m1.small_minute_cost = 0.0566666666666667
type_m1.small_month_cost = 2284.8
type_m1.small_running = 40
```

Cheers.
