### PR TITLE
One-line debian init script sample to exit with $? from status

### DIFF
--- a/resources/resmon_debian_rc
+++ b/resources/resmon_debian_rc
@@ -48,6 +48,7 @@ status() {
     else
             echo "Resmon is not running."
     fi
+    exit $?
 }
 restart() {
         stop


### PR DESCRIPTION
Exit with $? after status command so that things like puppet that rely on the exit status to determine if the service is running work properly
