### PR TITLE
return empty results if svcs fails, allowing SMF failures to be noticed

### DIFF
--- a/lib/Core/SmfDisabled.pm
+++ b/lib/Core/SmfDisabled.pm
@@ -79,6 +79,12 @@ sub handler {
     };
     my $svcs_output = run_command("$svcs_path -a");
     my @lines = grep { $_ ne '' } split /\n/, $svcs_output;
+
+    # svcs/smf is broken
+    if ($? && ! @lines) {
+        return {};
+    }
+
     for my $line (@lines) {
         my ($state, $start, $name) = split /\s+/, $line, 3;
         if ($name =~ $pattern) {

--- a/lib/Core/SmfMaintenance.pm
+++ b/lib/Core/SmfMaintenance.pm
@@ -71,6 +71,10 @@ sub handler {
     my @maintenance_services = map((split(/\s+/, $_))[2],
         grep(/^maintenance/, split(/\n/, $output)));
 
+    # svcs/smf is broken
+    if ($? && ! @maintenance_services) {
+        return {};
+    }
 
     return {
         "count" => [scalar(@maintenance_services), "i"],


### PR DESCRIPTION
If svcs fails for some reason or another, don't include result metrics instead of reporting 0 services in maintenance/disabled.
