### PR TITLE
Resmon Module for Chef Last Good Run

### DIFF
--- a/lib/Core/ChefLastGoodRun.pm
+++ b/lib/Core/ChefLastGoodRun.pm
@@ -81,7 +81,7 @@ sub handler {
         }
     }
 
-    my $report = File::Slurp::readfile($report_path);
+    my $report = File::Slurp::read_file($report_path);
     $report = decode_json($report);
 
     $metrics{elapsed} = [ $report->{elapsed_time}, 'F' ];


### PR DESCRIPTION
A Resmon module that works with the chef last-good-run report, to expose when chef-solo was last run, how long it took to run, and how many changes were made.
