### PR TITLE
Unescape all commas in configuration parameters

### DIFF
--- a/lib/Resmon/Config.pm
+++ b/lib/Resmon/Config.pm
@@ -63,7 +63,7 @@ sub new {
                 my $kvs = {};
                 my $check_name = $1;
                 my @params = split(/(?<!\\),/, $2);
-                grep { s/\\(.)/$1/ } @params;
+                grep { s/\\(.)/$1/g } @params;
                 grep { $kvs->{$1} = $2 if /^\s*(\S+)\s*=>\s*(\S(?:.*\S)?)\s*$/ }
                     @params;
                 my $object;


### PR DESCRIPTION
Fixes a bug in config parameters with escaped commas - only the first comma was un-escaped before being passed to the module.
