### PR TITLE
Circonus JSON HTTPTrap support

### DIFF
--- a/lib/Resmon/Config.pm
+++ b/lib/Resmon/Config.pm
@@ -18,7 +18,6 @@ sub split_ip_list {
        $int = unpack("N", pack("C4", split(/\./,$quad)));
        $mask = $int >> $matchbits;
        push @result => {mask => $mask, bits => $matchbits, allow => $allow};
-print STDERR "mask=$mask,bits=$matchbits,allow=$allow\n";
     }
     return \@result;
 }
@@ -155,6 +154,9 @@ sub new {
             }
             elsif(/\s*HOSTS\s+DENY\s+([^;]+)\s*;\s*/) {
                 push (@{$self->{hostsallow}}, @{split_ip_list($1,0)});
+                next;
+            } elsif(/\s*HTTPTRAP\s+(\S+)\s*;\s*/) {
+                $self->{httptrap} = $1;
                 next;
             } elsif(/\s*INCLUDE\s+(\S+)\s*;\s*/) {
                 my $incglob = $1;

--- a/resmon
+++ b/resmon
@@ -12,6 +12,7 @@ use Time::HiRes qw( gettimeofday tv_interval sleep );
 use POSIX qw( :sys_wait_h setsid );
 use Getopt::Long;
 use Data::Dumper;
+use Carp qw( verbose );
 use vars qw($config_file $debug $status_file $interface $port $config
 $status $update);
 
@@ -54,6 +55,8 @@ my $sigint = 0;
 sub sigint_handler { $sigint = 1; }
 $SIG{'INT'} = \&sigint_handler;
 
+$SIG{__DIE__} = \&Carp::confess;
+
 my $rmlast = undef;
 sub wait_interval {
     $rmlast = [gettimeofday] unless defined($rmlast);
@@ -86,6 +89,9 @@ $status->open();
 $status->serve_http_on($config->{interface}, $config->{port},
         $config->{authuser}, $config->{authpass}, $config->{hostsallow})
     if($config->{port});
+
+$status->init_http_trap($config->{httptrap})
+    if($config->{httptrap});
 
 while(1) {
     while(my($module_name, $mod_configs) = each %{$config->{Module}}) {
@@ -138,6 +144,10 @@ while(1) {
         }
     }
     $status->close();
+    
+    $status->http_trap($debug)
+        if($config->{httptrap});
+
     die "Exiting.\n" if($sigint);
     if ($sighup) {
         # Reload configuration (and modules) on SIGHUP
@@ -147,6 +157,8 @@ while(1) {
         # Needed to ensure any removed modules do not continue to show in the
         # web interface
         $status->clear();
+        $status->init_http_trap($config->{httptrap})
+            if($config->{httptrap});
     } else {
         reap_zombies();
         wait_interval();

--- a/resmon.conf.sample
+++ b/resmon.conf.sample
@@ -8,8 +8,8 @@ HOSTS ALLOW 10.80.116.112, 127.0.0.1;
 # a dotted decimal IPv4 addresses of the form a.b.c.d. to match incoming machine’s IP address exactly,
 # or an 'ipaddr/n' where ipaddr is the IP address and n is the number of one bits in the netmask.
 # the first match gives the result, if nothing matches IP is allowed.
-HOSTS DENY 10.80.117.128/25
-HOSTS ALLOW 10.80.116.0/23
+HOSTS DENY 10.80.117.128/25;
+HOSTS ALLOW 10.80.116.0/23;
 HOSTS DENY 0.0.0.0/0;
 
 # Resmon health check. Shows the hostname, svn revision and


### PR DESCRIPTION
The hand-rolled JSON support I submitted to the mailing list has been replaced by a dependency on CPAN's JSON library for better reliability.

Also, added missing semicolons in resmon.conf.sample
