### PR TITLE
Added support for iostat v10.2.0 output

### DIFF
--- a/lib/Core/Cpu.pm
+++ b/lib/Core/Cpu.pm
@@ -92,6 +92,7 @@ sub handler {
     for my $key (keys %metrics) {
         $metrics{$key} = [$metrics{$key}, 'I'];
     }
+    $metrics{usage} = [100 - $metrics{idle}[0], 'I'];
 
     return \%metrics;
 };

--- a/lib/Core/Cpu.pm
+++ b/lib/Core/Cpu.pm
@@ -63,6 +63,7 @@ sub handler {
     my $output = run_command("$vmstat_path 1 2 | $tail_path -1");
     my $osname = $^O;
     my %metrics;
+    my %ret_metrics;
     my @keys = qw( user system idle );
     my @values;
 
@@ -92,9 +93,9 @@ sub handler {
     for my $key (keys %metrics) {
         $metrics{$key} = [$metrics{$key}, 'I'];
     }
-    $metrics{usage} = [100 - $metrics{idle}[0], 'I'];
-
-    return \%metrics;
+    
+    $ret_metrics{usage} = [100 - $metrics{idle}[0], 'I'];
+    return \%ret_metrics;
 };
 
 1;

--- a/lib/Core/Cpu.pm
+++ b/lib/Core/Cpu.pm
@@ -71,13 +71,15 @@ sub handler {
     if ($osname eq 'solaris') {
         @values = (split(/\s+/, $output))[-3..-1];
     } elsif ($osname eq 'linux') {
-        if ( scalar split(/\s+/, $output) == 16 ){
+        my @o = split(/\s+/, $output);
+        my $output_num = @o;
+        if ($output_num == 16) {
             @values = (split(/\s+/, $output))[-4..-2];
-        } elsif( scalar split(/\s+/, $output) == 17 ) {
+        } elsif($output_num == 17) {
             @values = (split(/\s+/, $output))[-5..-3];
+        } else {
+            die "Unknown vmstat output";
         }
-
-        
     } elsif ($osname eq 'openbsd') {
         @values = (split(/\s+/, $output))[-3..-1];
     } elsif ($osname eq 'freebsd') {

--- a/lib/Core/Cpu.pm
+++ b/lib/Core/Cpu.pm
@@ -71,7 +71,13 @@ sub handler {
     if ($osname eq 'solaris') {
         @values = (split(/\s+/, $output))[-3..-1];
     } elsif ($osname eq 'linux') {
-        @values = (split(/\s+/, $output))[-5..-3];
+        if ( scalar split(/\s+/, $output) == 16 ){
+            @values = (split(/\s+/, $output))[-4..-2];
+        } elsif( scalar split(/\s+/, $output) == 17 ) {
+            @values = (split(/\s+/, $output))[-5..-3];
+        }
+
+        
     } elsif ($osname eq 'openbsd') {
         @values = (split(/\s+/, $output))[-3..-1];
     } elsif ($osname eq 'freebsd') {

--- a/lib/Core/Iostat.pm
+++ b/lib/Core/Iostat.pm
@@ -216,6 +216,7 @@ sub handler {
         my $interval = 5;
         my $count = 2;
         my $output = run_command("$iostat_path -x $interval $count");
+        my %ret_metrics;
         foreach (split(/\n/, $output)) {
             next if (/^Device\:.*/);
             if (/^(\S+)\s+(\S+)\s+(\S+)\s+(\S+)\s+(\S+)\s+(\S+)\s+(\S+)\s+(\S+)\s+(\S+)\s+(\S+)\s+(\S+)\s+(\S+)\s+(\S+)\s+(\S+).*/) {
@@ -224,7 +225,9 @@ sub handler {
                 $metrics{"${1}_reads_sec"} = [$4, 'n'];
                 $metrics{"${1}_writes_sec"} = [$5, 'n'];
                 $metrics{"${1}_kb_read_sec"} = [$6, 'n'];
+                $ret_metrics{"${1}_kb_read_sec"} = [$6, 'n'];
                 $metrics{"${1}_kb_write_sec"} = [$7, 'n'];
+                $ret_metrics{"${1}_kb_write_sec"} = [$7, 'n'];
                 $metrics{"${1}_avgrq_size"} = [$8, 'n'];
                 $metrics{"${1}_avgqu_size"} = [$9, 'n'];
                 $metrics{"${1}_await_msec"} = [$10, 'n'];
@@ -248,8 +251,8 @@ sub handler {
                 next;
             }
         }
-        if (keys %metrics) {
-            return \%metrics;
+        if (keys %ret_metrics) {
+            return \%ret_metrics;
         } else {
             die "No disks found\n";
         }

--- a/lib/Core/Iostat.pm
+++ b/lib/Core/Iostat.pm
@@ -141,6 +141,14 @@ The average queue length of the requests that were issued to the device.
 
 The average time (in milliseconds) for I/O requests issued to the device to be served.
 
+=item r_await_msec
+
+The average time (in milliseconds) for read requests issued to the device to be served.
+
+=item w_await_msec
+
+The average time (in milliseconds) for write requests issued to the device to be served.
+
 =item svctm_msec
 
 The average service time (in milliseconds) for I/O requests that were issued to the device.
@@ -210,18 +218,35 @@ sub handler {
         my $output = run_command("$iostat_path -x $interval $count");
         foreach (split(/\n/, $output)) {
             next if (/^Device\:.*/);
-            next unless (/^(\S+)\s+(\S+)\s+(\S+)\s+(\S+)\s+(\S+)\s+(\S+)\s+(\S+)\s+(\S+)\s+(\S+)\s+(\S+)\s+(\S+)\s+(\S+).*/);
-            $metrics{"${1}_rrqm_sec"} = [$2, 'n'];
-            $metrics{"${1}_wrqm_sec"} = [$3, 'n'];
-            $metrics{"${1}_reads_sec"} = [$4, 'n'];
-            $metrics{"${1}_writes_sec"} = [$5, 'n'];
-            $metrics{"${1}_rsec_sec"} = [$6, 'n'];
-            $metrics{"${1}_wsec_sec"} = [$7, 'n'];
-            $metrics{"${1}_avgrq_size"} = [$8, 'n'];
-            $metrics{"${1}_avgqu_size"} = [$9, 'n'];
-            $metrics{"${1}_await_msec"} = [$10, 'n'];
-            $metrics{"${1}_svctm_msec"} = [$11, 'n'];
-            $metrics{"${1}_util_pct"} = [$12, 'n'];
+            if (/^(\S+)\s+(\S+)\s+(\S+)\s+(\S+)\s+(\S+)\s+(\S+)\s+(\S+)\s+(\S+)\s+(\S+)\s+(\S+)\s+(\S+)\s+(\S+)\s+(\S+)\s+(\S+).*/) {
+                $metrics{"${1}_rrqm_sec"} = [$2, 'n'];
+                $metrics{"${1}_wrqm_sec"} = [$3, 'n'];
+                $metrics{"${1}_reads_sec"} = [$4, 'n'];
+                $metrics{"${1}_writes_sec"} = [$5, 'n'];
+                $metrics{"${1}_kb_read_sec"} = [$6, 'n'];
+                $metrics{"${1}_kb_write_sec"} = [$7, 'n'];
+                $metrics{"${1}_avgrq_size"} = [$8, 'n'];
+                $metrics{"${1}_avgqu_size"} = [$9, 'n'];
+                $metrics{"${1}_await_msec"} = [$10, 'n'];
+                $metrics{"${1}_r_await_msec"} = [$11, 'n'];
+                $metrics{"${1}_w_await_msec"} = [$12, 'n'];
+                $metrics{"${1}_svctm_msec"} = [$13, 'n'];
+                $metrics{"${1}_util_pct"} = [$14, 'n'];
+            } elsif (/^(\S+)\s+(\S+)\s+(\S+)\s+(\S+)\s+(\S+)\s+(\S+)\s+(\S+)\s+(\S+)\s+(\S+)\s+(\S+)\s+(\S+)\s+(\S+).*/) {
+                $metrics{"${1}_rrqm_sec"} = [$2, 'n'];
+                $metrics{"${1}_wrqm_sec"} = [$3, 'n'];
+                $metrics{"${1}_reads_sec"} = [$4, 'n'];
+                $metrics{"${1}_writes_sec"} = [$5, 'n'];
+                $metrics{"${1}_rsec_sec"} = [$6, 'n'];
+                $metrics{"${1}_wsec_sec"} = [$7, 'n'];
+                $metrics{"${1}_avgrq_size"} = [$8, 'n'];
+                $metrics{"${1}_avgqu_size"} = [$9, 'n'];
+                $metrics{"${1}_await_msec"} = [$10, 'n'];
+                $metrics{"${1}_svctm_msec"} = [$11, 'n'];
+                $metrics{"${1}_util_pct"} = [$12, 'n'];
+            } else {
+                next;
+            }
         }
         if (keys %metrics) {
             return \%metrics;

--- a/lib/Core/Memstat.pm
+++ b/lib/Core/Memstat.pm
@@ -138,6 +138,9 @@ sub handler {
         $metrics{MemFreeBufCache} = [
             ($metrics{MemFree}[0] + $metrics{Buffers}[0] +
                 $metrics{Cached}[0]), "L"];
+        $metrics{MemUsagePct} = [
+            printf("%.2f", ($metrics{MemTotal}[0] - $metrics{MemFree}[0] - 
+                $metrics{Buffers}[0] - $metrics{Cached}[0]) / $metrics{MemTotal}[0]), "L"];
         return \%metrics;
     } elsif ($osname eq 'freebsd') {
         my %metrics;

--- a/lib/Core/Memstat.pm
+++ b/lib/Core/Memstat.pm
@@ -139,8 +139,8 @@ sub handler {
             ($metrics{MemFree}[0] + $metrics{Buffers}[0] +
                 $metrics{Cached}[0]), "L"];
         $metrics{MemUsagePct} = [
-            printf("%.2f", ($metrics{MemTotal}[0] - $metrics{MemFree}[0] - 
-                $metrics{Buffers}[0] - $metrics{Cached}[0]) / $metrics{MemTotal}[0]), "L"];
+            sprintf("%.4f", ($metrics{MemTotal}[0] - $metrics{MemFree}[0] - 
+                $metrics{Buffers}[0] - $metrics{Cached}[0]) / $metrics{MemTotal}[0])*100, "L"];
         return \%metrics;
     } elsif ($osname eq 'freebsd') {
         my %metrics;

--- a/lib/Core/Memstat.pm
+++ b/lib/Core/Memstat.pm
@@ -128,6 +128,7 @@ sub handler {
         }
     } elsif ($osname eq 'linux') {
         my %metrics;
+        my %ret_metrics;
         open(MEMINFO, '/proc/meminfo') || die "Unable to read proc: $!\n";
         while (<MEMINFO>) {
             /(\w+)\:\s+(\d+).*/;
@@ -138,10 +139,10 @@ sub handler {
         $metrics{MemFreeBufCache} = [
             ($metrics{MemFree}[0] + $metrics{Buffers}[0] +
                 $metrics{Cached}[0]), "L"];
-        $metrics{MemUsagePct} = [
+        $ret_metrics{MemUsagePct} = [
             sprintf("%.4f", ($metrics{MemTotal}[0] - $metrics{MemFree}[0] - 
                 $metrics{Buffers}[0] - $metrics{Cached}[0]) / $metrics{MemTotal}[0])*100, "L"];
-        return \%metrics;
+        return \%ret_metrics;
     } elsif ($osname eq 'freebsd') {
         my %metrics;
         open(SYSCTL, 'sysctl hw.physmem vm.stats.vm |') || die "Unable to read sysctl: $!\n";

--- a/lib/Core/MysqlStatus.pm
+++ b/lib/Core/MysqlStatus.pm
@@ -70,14 +70,17 @@ sub handler {
     my $pass = $config->{'pass'};
     my $dbh = DBI->connect("DBI:mysql::$target;port=$port", $user, $pass);
 
-    my $select_query = "SHOW /*!50002 GLOBAL */ STATUS LIKE 'com_%'";
+    my $select_query = "SHOW /*!50002 GLOBAL */ STATUS";
     my $sth = $dbh->prepare($select_query);
     $sth->execute();
 
-    my %metrics;
+    my %tmpmetrics;
     while (my $result = $sth->fetchrow_hashref) {
-        $metrics{$result->{'Variable_name'}} = $result->{'Value'};
+        $tmpmetrics{$result->{'Variable_name'}} = $result->{'Value'};
     }
+    my %metrics;
+    $metrics{WriteQueries} = 0 + $tmpmetrics{Com_delete} + $tmpmetrics{Com_insert} + $tmpmetrics{Com_update};
+    $metrics{ReadQueries} = 0 + $tmpmetrics{Com_select};
 
     my $slave_query = "SHOW SLAVE STATUS";
     my $s_sth = $dbh->prepare($slave_query);

--- a/lib/Core/MysqlStatus.pm
+++ b/lib/Core/MysqlStatus.pm
@@ -70,7 +70,7 @@ sub handler {
     my $pass = $config->{'pass'};
     my $dbh = DBI->connect("DBI:mysql::$target;port=$port", $user, $pass);
 
-    my $select_query = "SHOW /*!50002 GLOBAL */ STATUS";
+    my $select_query = "SHOW /*!50002 GLOBAL */ STATUS LIKE 'com_%'";
     my $sth = $dbh->prepare($select_query);
     $sth->execute();
 

--- a/lib/Core/MysqlStatus.pm
+++ b/lib/Core/MysqlStatus.pm
@@ -81,6 +81,7 @@ sub handler {
     my %metrics;
     $metrics{WriteQueries} = 0 + $tmpmetrics{Com_delete} + $tmpmetrics{Com_insert} + $tmpmetrics{Com_update};
     $metrics{ReadQueries} = 0 + $tmpmetrics{Com_select};
+    $metrics{Connections} = $tmpmetrics{Connections};
 
     my $slave_query = "SHOW SLAVE STATUS";
     my $s_sth = $dbh->prepare($slave_query);

--- a/lib/Extra/MysqlSlowLog.pm
+++ b/lib/Extra/MysqlSlowLog.pm
@@ -1,0 +1,142 @@
+package Extra::MysqlSlowLog;
+
+#Extra::MysqlSlowLog {
+#   /var/lib/mysql/slow.log : port => 3306, user => monitor, pass => resmon62481
+#}
+
+# optional: debug => /path/to/log
+
+use strict;
+use warnings;
+use base 'Resmon::Module';
+use DBI;
+use File::Copy;
+use File::Basename;
+use List::Util qw(sum);
+
+my $logline = 0;
+my %metrics;
+
+my %query_types = (
+    select => [],
+    insert => [],
+    update => [],
+    delete => []
+);
+
+my ($thread_id, $schema, $qchit, $querytime, $locktime, $rowssent, $rowsexamined);
+my $query = "";
+my $tmpfilename = 'resmon-slowquerylog';
+
+sub mean { return @_ ? sum(@_)/@_ : 0 }
+
+sub identify_query {
+  my $query = shift;
+  $query =~ s/\R/ /g;
+  $query =~ s/\s+/ /g;
+  chomp($query);
+  return if (length($query) == 0);
+
+  my $unmatched = 1;
+  for my $q (split /;\s*/, $query) {
+    for my $k (keys %query_types) {
+      my $re = qr/^$k/i;
+      if ( $q =~ /$re/ ) {
+        debug("Matched $k: $q");
+        push @{$query_types{$k}}, $querytime*1000;
+        $unmatched = 0;
+      } 
+    }
+  }
+  if ($unmatched) { debug("Unmatched: <$query>"); }
+}
+
+sub debug {
+  my $logline = shift;
+
+  our $debug;
+  if ($debug) {
+    my $filename = $debug;
+    open(my $fh, '>>', $filename) or die "Could not open file '$filename' $!";
+    print $fh "$logline\n";
+    close $fh;
+  }
+
+}
+
+sub handler {
+  my $self = shift;
+  my $config = $self->{'config'};
+  my $slowquerylog = $self->{'check_name'};
+  my $port = $config->{'port'} || 3306;
+  my $user = $config->{'user'};
+  my $pass = $config->{'pass'};
+  our $debug = $config->{'debug'} || 0;
+
+  my($filename, $dirs, $suffix) = fileparse($slowquerylog);
+
+  move( $slowquerylog, $dirs.$tmpfilename );
+
+  my $dbh = DBI->connect("DBI:mysql::localhost;port=$port", $user, $pass);
+  my $select_query = "FLUSH LOGS";
+  my $sth = $dbh->prepare($select_query);
+  $sth->execute();
+
+
+  open( my $fh, $dirs.$tmpfilename ) or die "Can't read file";
+
+  while(<$fh>){
+    next if !$logline && !/^# User\@Host:/;
+    next if /^SET /i;
+    next if /^# Time:/i;
+    next if /^USE /i;
+    next if /^# Full_scan:/i;
+    next if /^# Filesort:/i;
+
+
+    if ($logline && /^# User\@Host:/) {
+      identify_query($query);
+      $querytime = undef;
+      $schema = undef;
+      $query = "";
+    }
+
+    $logline = 1;
+    
+    if (/^# Thread_id: (.+)\s*Schema: (.+)\s*QC_hit: (.+)/) {
+      ($thread_id, $schema, $qchit) = ($1, $2, $3);
+      my $line = "Thread ID: $thread_id, $schema, $qchit";
+      debug( $_ );
+      debug( $line );
+      next;
+    }
+
+    if (/^# Query_time: (\S+)\s*Lock_time: (\S+)\s*Rows_sent: (\S+)\s*Rows_examined: (.+)/) {
+      ($querytime, $locktime, $rowssent, $rowsexamined) = ($1, $2, $3, $4);
+      my $line = "Query Time: $querytime, $locktime, $rowssent, $rowsexamined";
+      debug($_);
+      debug($line);
+      next;
+    }
+
+    if (!/^# User\@Host:/) {
+      debug("RAW QUERY: <$query>");
+      $query = $query . $_;
+    }
+  }
+
+  identify_query($query); #catch last query in log
+
+
+  for my $k (sort keys %query_types) {
+      debug( uc($k).": ".mean(@{$query_types{$k}})." for ".scalar @{$query_types{$k}}." queries");
+      my $qps_avg = $k . '_qps';
+      $metrics{"$qps_avg"} = mean(@{$query_types{$k}});
+  }
+
+  return \%metrics;
+
+}
+
+1;
+

--- a/resmon.conf
+++ b/resmon.conf
@@ -1,0 +1,44 @@
+INTERVAL 60;
+PORT 62481;
+STATUSFILE ../resmon-status.txt;
+TIMEOUT 10;
+
+# HOSTS {ALLOW/DENY} lists are the coma or blank separated lists of a dotted
+# decimal IPv4 addresses of the form a.b.c.d. to match incoming machine’s IP
+# address exactly, or an 'ipaddr/n' where ipaddr is the IP address and n is
+# the number of one bits in the netmask.  the first match gives the result, if
+# nothing matches IP is allowed.
+#HOSTS ALLOW 10.80.116.112, 127.0.0.1;
+#HOSTS DENY 10.80.117.128/25;
+HOSTS ALLOW 67.207.202.136/32;
+HOSTS DENY 0.0.0.0/0;
+
+# Resmon health check. Shows the hostname, svn revision and
+# any problems with modules or the configuration file.
+#Core::Resmon {
+#  resmon : noop
+#}
+
+Core::Cpu {
+  local : noop
+}
+
+#Core::Load {
+#  local : noop
+#}
+
+Core::Iostat {
+  sd0 : noop
+}
+
+Core::Memstat {
+  local : noop
+}
+
+#Core::TcpService {
+#  ssh : host => 127.0.0.1, port => 22, timeout => 2
+#}
+
+#Core::File {
+#  /path/to/file : noop
+#}

--- a/resmon.conf
+++ b/resmon.conf
@@ -35,6 +35,10 @@ Core::Memstat {
   local : noop
 }
 
+Core::MysqlStatus {
+   127.0.0.1 : port => 3306, user => monitor, pass => resmon62481
+}
+
 #Core::TcpService {
 #  ssh : host => 127.0.0.1, port => 22, timeout => 2
 #}

--- a/resmon.conf
+++ b/resmon.conf
@@ -27,9 +27,9 @@ Core::Cpu {
 #  local : noop
 #}
 
-Core::Iostat {
-  sd0 : noop
-}
+#Core::Iostat {
+#  sd0 : noop
+#}
 
 Core::Memstat {
   local : noop

--- a/resmon.conf
+++ b/resmon.conf
@@ -27,9 +27,9 @@ Core::Cpu {
 #  local : noop
 #}
 
-#Core::Iostat {
-#  sd0 : noop
-#}
+Core::Iostat {
+  sd0 : noop
+}
 
 Core::Memstat {
   local : noop

--- a/resmon.conf
+++ b/resmon.conf
@@ -36,7 +36,7 @@ Core::Memstat {
 }
 
 Core::MysqlStatus {
-   127.0.0.1 : port => 3306, user => monitor, pass => resmon62481
+   localhost : port => 3306, user => monitor, pass => resmon62481
 }
 
 #Core::TcpService {


### PR DESCRIPTION
Hi!

It looks like the iostat processing is for version 9.0.4 (standard for RHEL6?).  Ubuntu 14.04 LTS ships sysstat/iostat version 10.2.0, which has some different output:

```
wfong@willbook:~$ iostat -x 
Linux 3.13.0-45-generic (willbook)  02/20/2015  _x86_64_    (2 CPU)

avg-cpu:  %user   %nice %system %iowait  %steal   %idle
           0.18    0.02    0.19    0.09    0.00   99.53

Device:         rrqm/s   wrqm/s     r/s     w/s    rkB/s    wkB/s avgrq-sz avgqu-sz   await r_await w_await  svctm  %util
sda               0.04     0.22    0.12    0.41     1.69     8.24    37.59     0.01   18.98    7.70   22.18   3.28   0.17
dm-0              0.00     0.00    0.15    0.63     1.69     8.07    25.04     0.08   96.35   11.27  116.81   2.32   0.18
dm-1              0.00     0.00    0.15    0.59     1.68     8.07    26.24     0.08  100.96   11.15  123.73   2.43   0.18
dm-2              0.00     0.00    0.00    0.00     0.00     0.00     8.00     0.00   46.05   46.05    0.00  44.43   0.00
```

I hope this works!

Thanks,
-will
