### PR TITLE
Fix file handle comparison and timeouts processing

### DIFF
--- a/lib/Core/TcpService.pm
+++ b/lib/Core/TcpService.pm
@@ -99,7 +99,7 @@ sub handler {
     connect($h, $s);
     $c->add($h);
     my ($fd) = $c->can_write($timeout);
-    if ($fd == $h) {
+    if (defined($fd) && (fileno($fd) == fileno($h))) {
         my $error = unpack("s", getsockopt($h, Socket::SOL_SOCKET, Socket::SO_ERROR));
         if ($error != 0) {
             close($h);
@@ -107,12 +107,16 @@ sub handler {
         }
         print $h $config->{'prepost'}."\r\n" if ($config->{'prepost'});
         ($fd) = $c->can_read($timeout);
-        if ($fd == $h) {
+        if (defined($fd) && (fileno($fd) == fileno($h))) {
             chomp($banner = <$h>);
             print $h $config->{'post'} if ($config->{'post'});
             close($h);
             $banner =~ s/([^\s\d\w.,;\/\\])/sprintf "\\%o", $1/eg;
         }
+    }
+    elsif (not defined($fd)) {
+      close($h);
+      return { 'status' => ['connection timeout', 's'] };
     }
     close($h);
 


### PR DESCRIPTION
The module as it is return "connection successful" when
connection timeouts.
Also, '==' can not compare file handles. We can use fileno()
function to compare numerically file numbers.